### PR TITLE
Hotfix to import Intent and Uri libraries

### DIFF
--- a/app/src/main/java/com/cse442/createteamname/MainActivity.java
+++ b/app/src/main/java/com/cse442/createteamname/MainActivity.java
@@ -1,5 +1,7 @@
 package com.cse442.createteamname;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;


### PR DESCRIPTION
These libraries weren't imported in dev, and are required to run the app properly